### PR TITLE
feat: add click event to map tooltips for city zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,10 +143,20 @@
 
         cities.forEach(({ city, lat, lng }) => {
             markers[city] = L.marker([lat, lng]).addTo(map)
-                .bindTooltip(`${city}: -`, { permanent: true, direction: "top", offset: [0, -10] })
-                .on('click', function() {
+                .bindTooltip(`${city}: -`, {
+                    permanent: true,
+                    direction: "top",
+                    offset: [0, -10],
+                    interactive: true  // 툴팁을 클릭 가능하게 만듦
+                })
+                .on('click', function () {
                     map.setView([lat, lng], 3);
                 });
+
+            // 툴팁 클릭 이벤트 추가
+            markers[city].getTooltip().addEventListener('click', function () {
+                map.setView([lat, lng], 3);
+            });
         });
 
         function updateDisplay(epochTime) {
@@ -197,7 +207,7 @@
 
         // 초기화 버튼을 맵 위에 추가
         L.Control.ResetView = L.Control.extend({
-            onAdd: function(map) {
+            onAdd: function (map) {
                 const btn = L.DomUtil.create('button', 'reset-view-btn');
                 btn.innerHTML = 'Reset View';
                 btn.style.backgroundColor = 'white';
@@ -205,19 +215,19 @@
                 btn.style.padding = '5px';
                 btn.style.cursor = 'pointer';
 
-                L.DomEvent.on(btn, 'click', function() {
+                L.DomEvent.on(btn, 'click', function () {
                     map.setView([0, 0], 2); // 초기 위치와 줌 레벨로 설정
                 });
 
                 return btn;
             },
 
-            onRemove: function(map) {
+            onRemove: function (map) {
                 // 아무것도 하지 않음
             }
         });
 
-        L.control.resetView = function(opts) {
+        L.control.resetView = function (opts) {
             return new L.Control.ResetView(opts);
         }
 


### PR DESCRIPTION
## 원인
- 지도의 도시 마커에는 클릭 시 줌 기능이 있었지만, 툴팁 클릭 시에는 동작하지 않아 사용자 경험이 일관적이지 않음

## 작업 내용
- 도시 툴팁에 클릭 이벤트 추가
  - 툴팁을 interactive하게 변경
  - 툴팁 클릭 시 해당 도시로 지도 이동 및 줌 기능 추가 (마커와 동일한 동작)

## 영향
- 사용자가 마커뿐만 아니라 툴팁을 클릭해도 동일한 줌 기능을 사용할 수 있게 됨
- 더 직관적이고 일관된 사용자 경험 제공